### PR TITLE
Update brew install instructions, no sudo needed

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ In order to install and use dqmagic you will need the `libmagic` library and hea
 
 * Debian/Ubuntu: `sudo apt-get install libmagic-dev`
 * Fedora/CentOS/RHEL: `sudo yum install file-devel`
-* OSX with homebrew: `sudo brew install libmagic`
+* OSX with homebrew: `brew install libmagic`
 
 At the moment dqmagic is not on CRAN, but you can install the current version
 via [drat](https://cran.r-project.org/package=drat):

--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-dqmagic
-=======
 
-[![Travis-CI Build Status](https://travis-ci.org/daqana/dqmagic.svg?branch=master)](https://travis-ci.org/daqana/dqmagic) [![Coverage Status](https://img.shields.io/codecov/c/github/daqana/dqmagic/master.svg)](https://codecov.io/github/daqana/dqmagic?branch=master)
+# dqmagic
 
-The dqmagic package provides an R interface for the [libmagic](https://linux.die.net/man/3/libmagic) file type identification library similar to the Unix [file](https://linux.die.net/man/1/file) command. This allows for file type identification based on a file's content instead of it's extension.
+[![Travis-CI Build
+Status](https://travis-ci.org/daqana/dqmagic.svg?branch=master)](https://travis-ci.org/daqana/dqmagic)
+[![Coverage
+Status](https://img.shields.io/codecov/c/github/daqana/dqmagic/master.svg)](https://codecov.io/github/daqana/dqmagic?branch=master)
 
-Installation
-------------
+The dqmagic package provides an R interface for the
+[libmagic](https://linux.die.net/man/3/libmagic) file type
+identification library similar to the Unix
+[file](https://linux.die.net/man/1/file) command. This allows for file
+type identification based on a file’s content instead of it’s extension.
 
-In order to install and use dqmagic you will need the `libmagic` library and headers:
+## Installation
 
--   Debian/Ubuntu: `sudo apt-get install libmagic-dev`
--   Fedora/CentOS/RHEL: `sudo yum install file-devel`
--   OSX with homebrew: `sudo brew install libmagic`
+In order to install and use dqmagic you will need the `libmagic` library
+and headers:
 
-At the moment dqmagic is not on CRAN, but you can install the current version via [drat](https://cran.r-project.org/package=drat):
+  - Debian/Ubuntu: `sudo apt-get install libmagic-dev`
+  - Fedora/CentOS/RHEL: `sudo yum install file-devel`
+  - OSX with homebrew: `brew install libmagic`
+
+At the moment dqmagic is not on CRAN, but you can install the current
+version via [drat](https://cran.r-project.org/package=drat):
 
 ``` r
 if (!requireNamespace("drat", quietly = TRUE)) install.packages("drat")
@@ -24,10 +32,10 @@ drat::addRepo("daqana")
 install.packages("dqmagic")
 ```
 
-Examples
---------
+## Examples
 
-This is a basic example which shows you how to determine the type of a file:
+This is a basic example which shows you how to determine the type of a
+file:
 
 ``` r
 library(dqmagic)


### PR DESCRIPTION
Just a small update to README. When using macOS, brew doesn't use sudo and specifically instructs users not to.